### PR TITLE
Search with GET request instead of POST request

### DIFF
--- a/events/templates/home.html
+++ b/events/templates/home.html
@@ -3,8 +3,8 @@
 {% load crispy_forms_tags %}
   {%block content%}
     <h1 class="">Events</h1>
-    <form class="d-inline" action="{% url 'home'%}" method="post">
-      {% csrf_token %}
+    <form class="d-inline" action="{% url 'home'%}" method="get">
+      <!-- {% csrf_token %} -->
       <fieldset>
         {{ form|crispy }}
       </fieldset>

--- a/events/views.py
+++ b/events/views.py
@@ -12,22 +12,18 @@ from .forms import EventForm, SearchForm
 from datetime import datetime
 
 def home(request):
-    show_old = False
-    if request.method == 'POST':
-        form = SearchForm(request.POST)
-        if form.is_valid():
-            search = form.cleaned_data.get('search')
-            show_old = form.cleaned_data.get('show_old')
-            events = Event.objects.filter(Q(name__icontains=search)|Q(details__icontains=search))
-        else:
-            messages.warning(request,'Something went wrong!')
-            events = Event.objects.all()
-            # then call to render below
-    else:
-        events = Event.objects.all()
-        form = SearchForm()
+    events = Event.objects.all()
+    form = SearchForm()
+    search = request.GET.get('search')
+    if search:
+        print(search)
+        events = events.filter(Q(name__icontains=search)|Q(details__icontains=search))
+        form.fields['search'].initial = search
+    show_old = request.GET.get('show_old')
     if not show_old:
         events = events.filter(event_date__gt=datetime.now())
+    else:
+        form.fields['show_old'].initial = True
     events = events.order_by('event_date')
     return render(request, 'home.html',{'events':events, 'form':form})
 
@@ -82,7 +78,7 @@ def edit_event(request, id):
             else:
                 messages.warning(request,'Something is wrong with your form')
                 return render(request, 'create_event.html', {'form' : form})
-                
+
         return render(request, 'create_event.html', {'form': form})
     else:
         messages.warning(request,'You do not have permission to edit this')

--- a/events/views.py
+++ b/events/views.py
@@ -13,17 +13,13 @@ from datetime import datetime
 
 def home(request):
     events = Event.objects.all()
-    form = SearchForm()
+    form = SearchForm(request.GET)
     search = request.GET.get('search')
     if search:
-        print(search)
         events = events.filter(Q(name__icontains=search)|Q(details__icontains=search))
-        form.fields['search'].initial = search
     show_old = request.GET.get('show_old')
     if not show_old:
         events = events.filter(event_date__gt=datetime.now())
-    else:
-        form.fields['show_old'].initial = True
     events = events.order_by('event_date')
     return render(request, 'home.html',{'events':events, 'form':form})
 


### PR DESCRIPTION
Passes variables by url queries like www.url.com?query=1
But Django has functions that handle this nicely. We still submit the data with a form. This stops the 'confirm form resubmission' alert that would happen when you refresh on the search page after searching.