### PR TITLE
Submit event signup request with a form rather than url

### DIFF
--- a/PurpleNut/urls.py
+++ b/PurpleNut/urls.py
@@ -30,8 +30,7 @@ urlpatterns = [
     url(r'^event/(\d+)/', event_views.event_detail, name='event detail'),
     url(r'^event/create/', event_views.create_event, name='create event'),
     url(r'^event_edit/(\d+)', event_views.edit_event, name='event edit'),
-    url(r'^event/signup/add/(\d+)', event_views.signup, name='event signup'),
-    url(r'^event/signup/rm/(\d+)', event_views.cancel_signup, name='event cancel signup'),
+    url(r'^event/signup/', event_views.signup, name='event signup'),
 
     url(r'^register/',user_views.register,name='register'),
     url(r'^login/',auth_views.LoginView.as_view(template_name='users/login.html') ,name='login'),

--- a/events/templates/event.html
+++ b/events/templates/event.html
@@ -11,11 +11,13 @@
     {% endif %}
     <!-- Sign up/Cancel Button -->
     {% if not event.is_past %}
-      {% if user not in event.signed_up.all %}
-        <a class="btn btn-secondary" href="{% url 'event signup' event.id %}">Signup</a>
-      {% else %}
-        <a class="btn btn-danger" href="{% url 'event cancel signup'  event.id %}">Cancel</a>
-      {% endif %}
+      <div class="float-right">
+        {% if user in event.signed_up.all %}
+          {% include "widgets/signUpButton.html" with event=event signed_up=True%}
+        {% else %}
+          {% include "widgets/signUpButton.html" with event=event%}
+        {% endif %}
+      </div>
     {% endif %}
     <div>
       <!-- Category -->

--- a/events/templates/widgets/signUpButton.html
+++ b/events/templates/widgets/signUpButton.html
@@ -1,0 +1,12 @@
+<div class="container">
+  <form action="{% url 'event signup' %}" method="POST">
+    {% csrf_token %}
+    <input type="hidden" name="id" value="{{ event.id }}">
+    {% if signed_up %}
+      <input type="hidden" name="signed_up" value="True">
+      <input type="submit" class="btn btn-danger" name="" value="Cancel Sign Up">
+    {% else %}
+      <input type="submit" class="btn btn-primary" name="" value="Sign Up">
+    {% endif %}
+  </form>
+</div>

--- a/events/views.py
+++ b/events/views.py
@@ -82,7 +82,7 @@ def edit_event(request, id):
             else:
                 messages.warning(request,'Something is wrong with your form')
                 return render(request, 'create_event.html', {'form' : form})
-                
+
         return render(request, 'create_event.html', {'form': form})
     else:
         messages.warning(request,'You do not have permission to edit this')
@@ -91,23 +91,20 @@ def edit_event(request, id):
 
 
 @login_required
-def signup(request, event_id):
-    try:
-        event = Event.objects.get(id=event_id)
-    except Event.DoesNotExist:
-        raise Http404('Event does\'t exist')
-    event.signed_up.add(request.user)
-    event.save()
-    messages.success(request,f'Signed up for { event.name }')
-    return redirect('home')
-
-@login_required
-def cancel_signup(request, event_id):
-    try:
-        event = Event.objects.get(id=event_id)
-    except Event.DoesNotExist:
-        raise Http404('Event does\'t exist')
-    event.signed_up.remove(request.user)
-    event.save()
-    messages.success(request,f'Canceled on { event.name }')
+def signup(request):
+    if request.method == 'POST':
+        id = request.POST.get('id')
+        try:
+            event = Event.objects.get(id=id)
+        except Event.DoesNotExist:
+            raise Http404('Event does\'t exist')
+        if request.POST.get('signed_up'):
+            event.signed_up.remove(request.user)
+            message = f'Canceled on {event.name}'
+        else:
+            event.signed_up.add(request.user)
+            message = f'Signed up for {event.name}'
+        event.save()
+        messages.success(request,message)
+        return redirect('home')
     return redirect('home')


### PR DESCRIPTION
Uses CSRF verification to ensure requests come from our site. Uses a modular html file for the signup button. Takes argument signed_up=True to alter form into a cancel signup form.